### PR TITLE
Moved logic for finding minimum y position

### DIFF
--- a/Assets/scripts/gameMechanics/move.cs
+++ b/Assets/scripts/gameMechanics/move.cs
@@ -14,7 +14,7 @@ public class move : MonoBehaviour {
 	private float ySize;	//offset of caterpillar
 	private float yheadPos;	//position of caterpillar head from body in world co-ordinates
 
-	public float yMin { get; set; }	//minimum y value for caterpillar to be active. must be calculated here as makes use of caterpillar body length values.
+//	public float yMin { get; set; }	//minimum y value for caterpillar to be active. must be calculated here as makes use of caterpillar body length values.
 
 	private int totalCaterpillars;
 	private float finishLine;
@@ -45,9 +45,6 @@ public class move : MonoBehaviour {
 	void setupPosition() {
 		yOffset = GetComponent<BoxCollider2D> ().offset.y;
 		ySize = GetComponent<BoxCollider2D> ().size.y/2;
-
-		yMin = transform.TransformPoint (new Vector3 (0, ySize - yOffset, 0)).y;
-		yMin = - ScreenVariables.worldHeight - yMin;	//used in manage caterpillar script
 
 		//finding x and y pos for caterpillar
 		float yWorldDim = transform.TransformPoint (new Vector3 (0, yOffset + ySize, 0)).y;	//offset from screenheight spawn pos to make caterpillar spawn off the screen

--- a/Assets/scripts/singletons/caterpillarManager.cs
+++ b/Assets/scripts/singletons/caterpillarManager.cs
@@ -36,7 +36,7 @@ public class caterpillarManager : MonoBehaviour {
 	public bool levelEnd{ get; set; }		//triggers end menu when true
 	public int caterpillarsInactivated{ get; set; }		//equals caterpillars killed + caterpillars passed over finish line
 	public int caterpillarsKilled{ get; set; }			//total caterpillars player successfully killed
-	private float minimunY{get;set;}			//minimum possible y value for caterpillars before going inactive
+	private float minimunY;			//minimum possible y value for caterpillars before going inactive
 
 	public GameObject levelComplete{ get; set; }
 
@@ -59,6 +59,7 @@ public class caterpillarManager : MonoBehaviour {
 		caterpillarsInactivated = 0;
 		caterpillarsKilled = 0;
 		findAllBugs ();		//finds all caterpillars currently in heirarchy
+		minimunY = findMinY();
 
 		timeSinceSpawn = spawnFrequency;	//set so that caterpillar spawns right away
 		timeAfterEnd = 0;
@@ -66,7 +67,7 @@ public class caterpillarManager : MonoBehaviour {
 
 	// Update is called once per frame
 	void Update () {
-		if (lifeManager.Instance.control) {
+		if (!levelEnd) {
 			timeSinceSpawn += Time.deltaTime;
 		}
 
@@ -82,9 +83,6 @@ public class caterpillarManager : MonoBehaviour {
 			}
 		}
 
-		if (lifeManager.Instance.control) {	//can only be done when control is true as before this there are no caterpillars to grab minimum y value from
-			findMinY ();
-		}
 
 		for (int i = 0; i < allCaterpillars.Length; i++) {
 			//inactivates caterpillars if they have surpassed finish line
@@ -130,9 +128,16 @@ public class caterpillarManager : MonoBehaviour {
 		allCaterpillars = GameObject.FindGameObjectsWithTag ("caterpillar");
 	}
 
-	void findMinY() {
-		minimunY = allCaterpillars [0].GetComponent<move> ().yMin;
-		minimunY += (ScreenVariables.worldHeight + finishLine);
+	float findMinY() {
+		float yOffset = caterpillars.GetComponent<BoxCollider2D> ().offset.y;
+		float ySize = caterpillars.GetComponent<BoxCollider2D> ().size.y/2;
+
+		float yMin = transform.TransformPoint (new Vector3 (0, ySize - yOffset, 0)).y;
+		yMin = - ScreenVariables.worldHeight - yMin;
+
+		//minimunY = allCaterpillars [0].GetComponent<move> ().yMin;
+		yMin += (ScreenVariables.worldHeight + finishLine);
+		return yMin;
 	}
 
 	public void resetMaxStreak() {


### PR DESCRIPTION
- The smallest possible y value a caterpillar can have before it is
inactivated is calculated only once in the caterpillar manager script
instead of in the move script
- Adding to the timer for the next caterpillar spawn is no longer
dependent on whether the player can control or not